### PR TITLE
Implement 'Last-Modified' header using cassandra write time

### DIFF
--- a/CassandraStore.js
+++ b/CassandraStore.js
@@ -126,7 +126,7 @@ CassandraStore.prototype.getTile = function(z, x, y, callback) {
     let self = this;
     return Promise.try(() => {
         if (z < self.minzoom || z > self.maxzoom) Err.throwNoTile();
-        let queryOptions = {
+        const queryOptions = {
             zoom: z,
             idx: qidx.xyToIndex(x, y, z),
             getWriteTime: self.setLastModified
@@ -134,7 +134,7 @@ CassandraStore.prototype.getTile = function(z, x, y, callback) {
         return self.queryTileAsync(queryOptions);
     }).then(row => {
         if (!row) Err.throwNoTile();
-        let headers = self.getHeaders();
+        const headers = self.getHeaders();
         if (self.setLastModified && row.writeTime){
             headers['Last-Modified'] = row.writeTime.toUTCString();
         }


### PR DESCRIPTION
This adds an option "setLastModified" (default: false).
The "Last-Modified" value is the date when tile was written on cassandra.